### PR TITLE
ODROID-N2: Support 8821cu module.

### DIFF
--- a/config/wifi.mk
+++ b/config/wifi.mk
@@ -52,4 +52,5 @@ PRODUCT_COPY_FILES += \
 	device/hardkernel/common/wifi/wifi_id_list.txt:vendor/etc/wifi_id_list.txt \
 	device/hardkernel/common/wifi/8192cu:vendor/etc/modprobe.d/8192cu \
 	device/hardkernel/common/wifi/8812au:vendor/etc/modprobe.d/8812au \
+	device/hardkernel/common/wifi/8821cu:vendor/etc/modprobe.d/8821cu \
 	device/hardkernel/common/wifi/rt2800usb:vendor/etc/modprobe.d/rt2800usb


### PR DESCRIPTION
Signed-off-by: Chris KIM <codewalker@hardkernel.com>
Change-Id: I3a246c379e9c62ef56bbe7771c76ffdff05d5758